### PR TITLE
Add shortData to fitbit sleep

### DIFF
--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitSleepAvroConverter.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitSleepAvroConverter.java
@@ -126,6 +126,27 @@ public class FitbitSleepAvroConverter extends FitbitAvroConverter {
                 return new TopicData(intermediateOffset, topic, sleep);
               })
               .collect(Collectors.toList());
+              
+        if (isStages) {
+          List<TopicData> shortData = iterableToStream(s.get("levels").get("shortData"))
+            .map(d -> {
+              IndexedRecord sleep;
+              String topic;
+              String dateTime = d.get("dateTime").asText();
+              int duration = d.get("seconds").asInt();
+              String level = d.get("level").asText(); 
+              sleep = new FitbitSleepStage(
+                dateTime,
+                timeReceived,
+                duration,
+                STAGES_MAP.getOrDefault(level, FitbitSleepStageLevel.UNKNOWN));
+              )
+              topic = sleepStagesTopic;
+              return new TopicData(intermediateOffset, topic, sleep);
+            })
+            .collect(Collectors.toList());
+          allRecords.addAll(shortData);
+        }
 
           // The final group gets the actual offset, to ensure that the group does not get queried
           // again.


### PR DESCRIPTION
Hi, I noticed we don't collect the "shortData" from the fitbit sleep stages. It contains segments <3min, from the fitbit website (https://dev.fitbit.com/build/reference/web-api/sleep/ ):

"Note: shortData is only included for stages sleep logs and includes wake periods that are 3 minutes or less in duration. This distinction is to simplify graphically distinguishing short wakes from longer wakes, but they are physiologically equivalent."

I wasn't sure whether to make a pull request here or on RADAR-base. I also don't know how to set up a test for this, and since I have no experience with Java it would defo be worth looking over (if we want to add support for shortData).