### PR TITLE
Minor fixes

### DIFF
--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
@@ -154,6 +154,13 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
   private static final String FITBIT_USER_REPOSITORY_FIRESTORE_USER_COLLECTION_DISPLAY = "Firebase User collection name.";
   private static final String FITBIT_USER_REPOSITORY_FIRESTORE_USER_COLLECTION_DEFAULT = "users";
 
+  public static final String FITBIT_TASK_RECONFIGURE_INTERVAL = "fitbit.task.reconfigure.interval";
+  private static final String FITBIT_TASK_RECONFIGURE_INTERVAL_DOC = "How often to check for task" +
+      " reconfiguration in minutes";
+  private static final int FITBIT_TASK_RECONFIGURE_INTERVAL_DEFAULT = 60;
+  private static final String FITBIT_TASK_RECONFIGURE_INTERVAL_DISPLAY = "Task reconfiguration " +
+      "interval in minutes.";
+
   private UserRepository userRepository;
   private final Headers clientCredentials;
 
@@ -401,6 +408,16 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
             ++orderInGroup,
             Width.SHORT,
             FITBIT_USER_REPOSITORY_FIRESTORE_USER_COLLECTION_DISPLAY)
+
+        .define(FITBIT_TASK_RECONFIGURE_INTERVAL,
+            Type.INT,
+            FITBIT_TASK_RECONFIGURE_INTERVAL_DEFAULT,
+            Importance.HIGH,
+            FITBIT_TASK_RECONFIGURE_INTERVAL_DOC,
+            group,
+            ++orderInGroup,
+            Width.SHORT,
+            FITBIT_TASK_RECONFIGURE_INTERVAL_DISPLAY)
         ;
   }
 
@@ -534,5 +551,9 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
         throw new ConfigException("Fitbit user repository token URL is invalid.");
       }
     }
+  }
+
+  public int getFitbitTaskReconfigureInterval() {
+    return getInt(FITBIT_TASK_RECONFIGURE_INTERVAL);
   }
 }

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitSourceConnector.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitSourceConnector.java
@@ -56,7 +56,7 @@ public class FitbitSourceConnector extends AbstractRestSourceConnector {
           Set<? extends User> newUsers =
               getConfig(props, false).getUserRepository(repository).stream()
                   .collect(Collectors.toSet());
-          if (configuredUsers != null && !newUsers.equals(configuredUsers)) {
+          if (configuredUsers!=null && !newUsers.equals(configuredUsers)) {
             logger.info("User info mismatch found. Requesting reconfiguration...");
             reconfigure();
           }
@@ -66,7 +66,7 @@ public class FitbitSourceConnector extends AbstractRestSourceConnector {
       } else {
         logger.info("No pending updates found. Not attempting to refresh users.");
       }
-    }, 0, 5, TimeUnit.MINUTES);
+    }, 3, getConfig(props).getFitbitTaskReconfigureInterval(), TimeUnit.MINUTES);
   }
 
   @Override
@@ -101,7 +101,7 @@ public class FitbitSourceConnector extends AbstractRestSourceConnector {
   private List<Map<String, String>> configureTasks(int maxTasks) {
     Map<String, String> baseConfig = config.originalsStrings();
     FitbitRestSourceConnectorConfig fitbitConfig = getConfig(baseConfig);
-    if (repository == null) {
+    if (repository==null) {
       repository = fitbitConfig.getUserRepository(null);
     }
     // Divide the users over tasks

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/firebase/CovidCollabFirebaseUserRepository.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/firebase/CovidCollabFirebaseUserRepository.java
@@ -159,7 +159,7 @@ public class CovidCollabFirebaseUserRepository extends FirebaseUserRepository {
     return covidCollabFirestore.getUsers().stream().filter(user ->
         (
             fitbitConfig.getFitbitUsers().isEmpty()
-                || fitbitConfig.getFitbitUsers().contains(user.getId()))
+                || fitbitConfig.getFitbitUsers().contains(user.getVersionedId()))
             && (
             fitbitConfig.getExcludedFitbitUsers().isEmpty()
                 || !fitbitConfig.getExcludedFitbitUsers().contains(user.getId()))

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/firebase/CovidCollabFirestore.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/firebase/CovidCollabFirestore.java
@@ -35,6 +35,7 @@ public class CovidCollabFirestore {
   private final CollectionReference fitbitCollection;
   private ListenerRegistration fitbitCollectionListenerRegistration;
   private boolean hasPendingUpdates = true;
+  private int countAdded = 0;
 
   private CovidCollabFirestore(FitbitRestSourceConnectorConfig fitbitConfig) {
     this.userCollection =
@@ -169,12 +170,13 @@ public class CovidCollabFirestore {
       if (checkValidUser(user)) {
         FirebaseUser user1 = cachedUsers.put(user.getId(), user);
         if (user1==null) {
-          logger.info("Created new User: {}", user.getId());
+          logger.debug("Created new User: {}", user.getId());
         } else {
-          logger.info("Updated existing user: {}", user1);
+          logger.debug("Updated existing user: {}", user1);
           logger.debug("Updated user is: {}", user);
         }
         hasPendingUpdates = true;
+        countAdded++;
       } else if (user!=null && !user.isComplete()) {
         logger.info("User is not complete, skipping...");
         removeUser(fitbitDocumentSnapshot);
@@ -228,7 +230,7 @@ public class CovidCollabFirestore {
         snapshots.getDocuments().size());
     for (DocumentChange dc : snapshots.getDocumentChanges()) {
       try {
-        logger.info("Type: {}", dc.getType());
+        logger.debug("Type: {}", dc.getType());
         switch (dc.getType()) {
           case ADDED:
           case MODIFIED:
@@ -246,5 +248,7 @@ public class CovidCollabFirestore {
             exc);
       }
     }
+    logger.info("Added/Updated {} Users", countAdded);
+    countAdded = 0;
   }
 }

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/firebase/CovidCollabFirestore.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/firebase/CovidCollabFirestore.java
@@ -33,8 +33,6 @@ public class CovidCollabFirestore {
   private final ConcurrentHashMap<String, FirebaseUser> cachedUsers = new ConcurrentHashMap<>();
   private final CollectionReference userCollection;
   private final CollectionReference fitbitCollection;
-  private final List<String> allowedUsers;
-  private final List<String> excludedUsers;
   private ListenerRegistration fitbitCollectionListenerRegistration;
   private boolean hasPendingUpdates = true;
 
@@ -43,8 +41,6 @@ public class CovidCollabFirestore {
         getFirestore().collection(fitbitConfig.getFitbitUserRepositoryFirestoreUserCollection());
     this.fitbitCollection =
         getFirestore().collection(fitbitConfig.getFitbitUserRepositoryFirestoreFitbitCollection());
-    this.allowedUsers = fitbitConfig.getFitbitUsers();
-    this.excludedUsers = fitbitConfig.getExcludedFitbitUsers();
 
     /**
      * Currently, we only listen for the fitbit collection, as it contains most information while
@@ -79,12 +75,10 @@ public class CovidCollabFirestore {
 
   private static boolean configEquals(FitbitRestSourceConnectorConfig c1,
                                       FitbitRestSourceConnectorConfig c2) {
-    return c1.getFitbitUsers().equals(c2.getFitbitUsers())
-        && c1.getFitbitUserRepositoryFirestoreFitbitCollection()
+    return c1.getFitbitUserRepositoryFirestoreFitbitCollection()
         .equals(c2.getFitbitUserRepositoryFirestoreFitbitCollection())
         && c1.getFitbitUserRepositoryFirestoreUserCollection()
         .equals(c2.getFitbitUserRepositoryFirestoreUserCollection())
-        && c1.getExcludedFitbitUsers().equals(c2.getExcludedFitbitUsers())
         && c1.hasIntradayAccess()==c2.hasIntradayAccess();
   }
 
@@ -198,9 +192,7 @@ public class CovidCollabFirestore {
   /**
    * We add the user based on the following conditions -
    * 1) The user is not null
-   * 2) the user is allowed in the configuration
-   * 3) the user is not excluded in the configuration
-   * 4) The user has not auth errors signified by the auth_result key in firebase. We accept 409
+   * 2) The user has not auth errors signified by the auth_result key in firebase. We accept 409
    * code too since it is just a concurrent request conflict and does not effect the validity of
    * the tokens.
    *
@@ -210,8 +202,6 @@ public class CovidCollabFirestore {
   private boolean checkValidUser(FirebaseUser user) {
     return user!=null
         && user.isComplete()
-        && (allowedUsers.isEmpty() || allowedUsers.contains(user.getId()))
-        && (excludedUsers.isEmpty() || !excludedUsers.contains(user.getId()))
         && (user.getFitbitAuthDetails().getAuthResult()==null
         || user.getFitbitAuthDetails().getAuthResult().getHttpCode()==200
         || user.getFitbitAuthDetails().getAuthResult().getHttpCode()==409

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/firebase/CovidCollabFirestore.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/firebase/CovidCollabFirestore.java
@@ -200,7 +200,9 @@ public class CovidCollabFirestore {
    * 1) The user is not null
    * 2) the user is allowed in the configuration
    * 3) the user is not excluded in the configuration
-   * 4) The user has not auth errors signified by the auth_result key in firebase
+   * 4) The user has not auth errors signified by the auth_result key in firebase. We accept 409
+   * code too since it is just a concurrent request conflict and does not effect the validity of
+   * the tokens.
    *
    * @param user The user to check for validity
    * @return true if user is valid, false otherwise.
@@ -211,7 +213,9 @@ public class CovidCollabFirestore {
         && (allowedUsers.isEmpty() || allowedUsers.contains(user.getId()))
         && (excludedUsers.isEmpty() || !excludedUsers.contains(user.getId()))
         && (user.getFitbitAuthDetails().getAuthResult()==null
-        || user.getFitbitAuthDetails().getAuthResult().getHttpCode()==200);
+        || user.getFitbitAuthDetails().getAuthResult().getHttpCode()==200
+        || user.getFitbitAuthDetails().getAuthResult().getHttpCode()==409
+    );
   }
 
   private void removeUser(DocumentSnapshot documentSnapshot) {


### PR DESCRIPTION
- handles 409 error (does not update in firebase) and does not exclude users with 409 code. Fixes #5 
- Increase the task reconfiguration interval to 1H. Also makes it configurable. Fixes #6 
- Better handling of the distribution of users among tasks for Firestore user repo